### PR TITLE
add minimal workflow for keymap drawer

### DIFF
--- a/.github/workflows/draw.yml
+++ b/.github/workflows/draw.yml
@@ -1,0 +1,22 @@
+name: Draw ZMK keymaps
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "config/*.keymap"
+      - "config/*.dtsi"
+      - "keymap_drawer.config.yaml"
+
+jobs:
+  draw:
+    uses: stijnveenman/keymap-drawer/.github/workflows/draw-zmk.yml@feature/west-init
+    # use below once https://github.com/caksoylar/keymap-drawer/pull/107 has been merged
+    # uses: caksoylar/keymap-drawer/.github/workflows/draw-zmk.yml@main
+    with:
+      keymap_patterns: "config/*.keymap"
+      config_path: 'keymap_drawer.config.yaml'
+      destination: 'artifact'
+      west_config_path: './config/'
+      # install repo and branch can be removed once https://github.com/caksoylar/keymap-drawer/pull/105 has been merged
+      install_repo: 'https://github.com/stijnveenman/keymap-drawer.git'
+      install_branch: 'feature/additional_includes'

--- a/keymap_drawer.config.yaml
+++ b/keymap_drawer.config.yaml
@@ -1,0 +1,3 @@
+parse_config:
+  zmk_additional_includes:
+    - "zmk-helpers/include"


### PR DESCRIPTION
Thanks again for the awesome config and write up about it, it gave me a great starting point for my configuration. Consider this my thank you note. :)

It is now possible to use keymap drawer with v2 of `zmk-helpers`

This PR shows a minimal implementation of it. There is still more configuration required to make it look decent. 
With some inspiration of https://github.com/minusfive/zmk-config i have a more complete config on my fork of your config. 

Since i made quite some changes to your config, also removing some keys, my config is probably still incomplete for yours. But might give a more complete starting point. See: https://github.com/stijnveenman/zmk-config/blob/main/keymap_drawer.config.yaml

Which renders:
![image](https://github.com/user-attachments/assets/26958ee9-d5f2-4761-9217-d14f5b10f347)

An example of this minimal workflow can be found at: https://github.com/stijnveenman/zmk-config/actions/runs/9920716711

Note: keymap-drawer renders all .keymap files by default (configured in yaml),so with your multiple keyboard configurations it will try and render `base.keymap` which will fail. But it will still continue with the rest of them. Since i only have one keyboard i hardcoded mine
