### PR TITLE
made required location of shield files for local builds explicit in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -344,7 +344,8 @@ provides
 [completion scripts](https://github.com/casey/just?tab=readme-ov-file#shell-completion-scripts)
 for many shells.)
 
-To add custom shields place the files you would put in `boards/shields` in `zmk/app/boards/shields` and add the board+shield to the `build.yaml`. Then compile your firmware as stated above with `just build <shieldname>`.
+To add custom shields `$SCHIELD_NAME` clone its files to a directory `$DIR` or create a new one based of [the unified zmk config template](https://github.com/zmkfirmware/unified-zmk-config-template/) and clone it to `$DIR`.
+To build this custom shield use `west build -p -s zmk/app -b $BOARD_NAME -- -DZMK_EXTRA_MODULES="$ABSOLUTE_PATH_TO_$DIR" -DSHIELD=$SHIELD_NAME` where `$BOARD_NAME` is the name of the MCU-board that your shield is extending. E.g. for building the shield `endgame`, which is based on a `nice_nano_v2` board, with the files lying in `/home/user/my-endgame-directory` the command would be `west build -p -s zmk/app -b nice_nano_v2 -- -DZMK_EXTRA_MODULES="/home/user/my-endgame-directory" -DSHIELD=endgame`.
 
 #### Drawing the keymap
 

--- a/readme.md
+++ b/readme.md
@@ -344,6 +344,8 @@ provides
 [completion scripts](https://github.com/casey/just?tab=readme-ov-file#shell-completion-scripts)
 for many shells.)
 
+To add custom shields place the files you would put in `boards/shields` in `zmk/app/boards/shields` and add the board+shield to the `build.yaml`. Then compile your firmware as stated above with `just build <shieldname>`.
+
 #### Drawing the keymap
 
 The build environment packages


### PR DESCRIPTION
I found it quite unintuitive that files for custom shields need to go into `zmk/app/boards/shields` instead of `boards/shields` so I made it explicit in the readme.
When the files are in `boards/shields` one get error messages, that the shield files are used, but at the same time, that the shield is invalid.

Thank you for the amazing repo and the local toolchain setup 💜