### PR TITLE
Justfile updates

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -6,12 +6,15 @@ build := absolute_path('.build')
 out := absolute_path('firmware')
 draw := absolute_path('draw')
 
+default_build_matrix := "build.yaml"
+
 # parse build.yaml and filter targets by expression
-_parse_targets $expr:
+[arg("matrix-file", short="f", long="matrix-file")]
+_parse_targets $expr matrix-file=default_build_matrix:
     #!/usr/bin/env bash
     attrs="[.board, .shield, .snippet, .\"artifact-name\"]"
     filter="(($attrs | map(. // [.]) | combinations), ((.include // {})[] | $attrs)) | join(\",\")"
-    echo "$(yq -r "$filter" build.yaml | grep -v "^," | grep -i "${expr/#all/.*}")"
+    echo "$(yq -r "$filter" {{matrix-file}} | grep -v "^," | grep -i "${expr/#all/.*}")"
 
 # build firmware for single board & shield combination
 _build_single $board $shield $snippet $artifact *west_args:
@@ -31,10 +34,11 @@ _build_single $board $shield $snippet $artifact *west_args:
     fi
 
 # build firmware for matching targets
-build expr *west_args:
+[arg("matrix-file", short="f", long="matrix-file")]
+build expr matrix-file=default_build_matrix *west_args:
     #!/usr/bin/env bash
     set -euo pipefail
-    targets=$(just _parse_targets {{ expr }})
+    targets=$(just _parse_targets --matrix-file={{ matrix-file }} {{ expr }})
 
     [[ -z $targets ]] && echo "No matching targets found. Aborting..." >&2 && exit 1
     echo "$targets" | while IFS=, read -r board shield snippet artifact; do
@@ -68,8 +72,9 @@ init:
     west zephyr-export
 
 # list build targets
-list:
-    @just _parse_targets all | sed 's/,*$//' | sort | column
+[arg("matrix-file", short="f", long="matrix-file")]
+list matrix-file=default_build_matrix:
+    @just _parse_targets --matrix-file={{matrix-file}} all | sed 's/,*$//' | sort | column
 
 # update west
 update:

--- a/Justfile
+++ b/Justfile
@@ -22,7 +22,7 @@ _parse_targets $expr matrix-file=default_build_matrix:
 _build_single $board $shield $snippet $artifact cmake_args *west_args:
     #!/usr/bin/env bash
     set -euo pipefail
-    artifact="${artifact:-${shield:+${shield// /+}-}${board}}"
+    artifact="${artifact:-${shield:+${shield// /+}-}${board%%/*}}"
     build_dir="{{ build / '$artifact' }}"
 
     echo "Building firmware for $artifact..."

--- a/Justfile
+++ b/Justfile
@@ -1,3 +1,5 @@
+# this Justfile requires python-yq, not golang-yq
+# the latter will fail with an error about `combinations` (used in `_parse_targets`)
 default:
     @just --list --unsorted
 

--- a/Justfile
+++ b/Justfile
@@ -8,15 +8,14 @@ build := absolute_path('.build')
 out := absolute_path('firmware')
 draw := absolute_path('draw')
 
-default_build_matrix := "build.yaml"
+build_matrix := "build.yaml"
 
 # parse build.yaml and filter targets by expression
-[arg("matrix-file", short="f", long="matrix-file")]
-_parse_targets $expr matrix-file=default_build_matrix:
+_parse_targets $expr:
     #!/usr/bin/env bash
     attrs="[.board, .shield, .snippet, .\"artifact-name\", .\"cmake-args\"]"
     filter="(($attrs | map(. // [.]) | combinations), ((.include // {})[] | $attrs)) | join(\",\")"
-    echo "$(yq -r "$filter" {{matrix-file}} | grep -v "^," | grep -i "${expr/#all/.*}")"
+    echo "$(yq -r "$filter" {{build_matrix}} | grep -v "^," | grep -i "${expr/#all/.*}")"
 
 # build firmware for single board & shield combination
 _build_single $board $shield $snippet $artifact cmake_args *west_args:
@@ -36,11 +35,10 @@ _build_single $board $shield $snippet $artifact cmake_args *west_args:
     fi
 
 # build firmware for matching targets
-[arg("matrix-file", short="f", long="matrix-file")]
-build expr matrix-file=default_build_matrix *west_args:
+build expr *west_args:
     #!/usr/bin/env bash
     set -euo pipefail
-    targets=$(just _parse_targets --matrix-file={{ matrix-file }} {{ expr }})
+    targets=$(just build_matrix={{build_matrix}} _parse_targets {{ expr }})
 
     [[ -z $targets ]] && echo "No matching targets found. Aborting..." >&2 && exit 1
     echo "$targets" | while IFS=, read -r board shield snippet artifact cmake_args; do
@@ -74,9 +72,8 @@ init:
     west zephyr-export
 
 # list build targets
-[arg("matrix-file", short="f", long="matrix-file")]
-list matrix-file=default_build_matrix:
-    @just _parse_targets --matrix-file={{matrix-file}} all | sed 's/,*,[^,]*$//' | sort | column
+list:
+    @just build_matrix={{build_matrix}} _parse_targets all | sed 's/,*,[^,]*$//' | sort | column
 
 # update west
 update:

--- a/Justfile
+++ b/Justfile
@@ -22,7 +22,7 @@ _parse_targets $expr matrix-file=default_build_matrix:
 _build_single $board $shield $snippet $artifact cmake_args *west_args:
     #!/usr/bin/env bash
     set -euo pipefail
-    artifact="${artifact:-${shield:+${shield// /+}-}${board%%/*}}"
+    artifact="${artifact:-${shield:+${shield// /+}-}${board//\//_}}"
     build_dir="{{ build / '$artifact' }}"
 
     echo "Building firmware for $artifact..."

--- a/Justfile
+++ b/Justfile
@@ -14,12 +14,12 @@ default_build_matrix := "build.yaml"
 [arg("matrix-file", short="f", long="matrix-file")]
 _parse_targets $expr matrix-file=default_build_matrix:
     #!/usr/bin/env bash
-    attrs="[.board, .shield, .snippet, .\"artifact-name\"]"
+    attrs="[.board, .shield, .snippet, .\"artifact-name\", .\"cmake-args\"]"
     filter="(($attrs | map(. // [.]) | combinations), ((.include // {})[] | $attrs)) | join(\",\")"
     echo "$(yq -r "$filter" {{matrix-file}} | grep -v "^," | grep -i "${expr/#all/.*}")"
 
 # build firmware for single board & shield combination
-_build_single $board $shield $snippet $artifact *west_args:
+_build_single $board $shield $snippet $artifact cmake_args *west_args:
     #!/usr/bin/env bash
     set -euo pipefail
     artifact="${artifact:-${shield:+${shield// /+}-}${board}}"
@@ -27,7 +27,7 @@ _build_single $board $shield $snippet $artifact *west_args:
 
     echo "Building firmware for $artifact..."
     west build -s zmk/app -d "$build_dir" -b $board {{ west_args }} ${snippet:+-S "$snippet"} -- \
-        -DZMK_CONFIG="{{ config }}" ${shield:+-DSHIELD="$shield"}
+        -DZMK_CONFIG="{{ config }}" ${shield:+-DSHIELD="$shield"} {{ cmake_args }}
 
     if [[ -f "$build_dir/zephyr/zmk.uf2" ]]; then
         mkdir -p "{{ out }}" && cp "$build_dir/zephyr/zmk.uf2" "{{ out }}/$artifact.uf2"
@@ -43,8 +43,8 @@ build expr matrix-file=default_build_matrix *west_args:
     targets=$(just _parse_targets --matrix-file={{ matrix-file }} {{ expr }})
 
     [[ -z $targets ]] && echo "No matching targets found. Aborting..." >&2 && exit 1
-    echo "$targets" | while IFS=, read -r board shield snippet artifact; do
-        just _build_single "$board" "$shield" "$snippet" "$artifact" {{ west_args }}
+    echo "$targets" | while IFS=, read -r board shield snippet artifact cmake_args; do
+        just _build_single "$board" "$shield" "$snippet" "$artifact" "$cmake_args" {{ west_args }}
     done
 
 # clear build cache and artifacts
@@ -76,7 +76,7 @@ init:
 # list build targets
 [arg("matrix-file", short="f", long="matrix-file")]
 list matrix-file=default_build_matrix:
-    @just _parse_targets --matrix-file={{matrix-file}} all | sed 's/,*$//' | sort | column
+    @just _parse_targets --matrix-file={{matrix-file}} all | sed 's/,*,[^,]*$//' | sort | column
 
 # update west
 update:

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,3 @@
-# this Justfile requires python-yq, not golang-yq
-# the latter will fail with an error about `combinations` (used in `_parse_targets`)
 default:
     @just --list --unsorted
 
@@ -11,7 +9,7 @@ draw := absolute_path('draw')
 build_matrix := "build.yaml"
 
 # parse build.yaml and filter targets by expression
-_parse_targets $expr:
+_parse_targets $expr: _check_yq_version
     #!/usr/bin/env bash
     attrs="[.board, .shield, .snippet, .\"artifact-name\", .\"cmake-args\"]"
     filter="(($attrs | map(. // [.]) | combinations), ((.include // {})[] | $attrs)) | join(\",\")"
@@ -58,7 +56,7 @@ clean-nix:
     nix-collect-garbage --delete-old
 
 # parse & plot keymap
-draw:
+draw: _check_yq_version
     #!/usr/bin/env bash
     set -euo pipefail
     keymap -c "{{ draw }}/config.yaml" parse -z "{{ config }}/base.keymap" --virtual-layers Combos >"{{ draw }}/base.yaml"
@@ -82,6 +80,16 @@ update:
 # upgrade zephyr-sdk and python dependencies
 upgrade-sdk:
     nix flake update --flake .
+
+# warn user if they are using golang-yq and not python-yq
+[no-exit-message]
+_check_yq_version:
+    #!/usr/bin/env bash
+    if yq --help 2>&1 | grep -qi 'eval'; then
+        echo "This script requires python-yq, but PATH contains golang-yq" >&2
+        echo "Please install python-yq or use the included nix shell" >&2
+        exit 1
+    fi
 
 [no-cd]
 test $testpath *FLAGS:


### PR DESCRIPTION
While working on a different project (https://github.com/keebs34/zmk-config-selenium), I needed to add a few features to the Justfile I picked from this repo.

Since they are generic, I’m proposing them for inclusion:
- **just: Add --matrix-file arg to `list` and `build`**
- **just: Add comment about python-yq VS golang-yq**
- **just: Handle cmake-args in matrix file**
- **just: Strip board variant when generating artifact name**
