### PR TITLE
justfile: Add 'flash' target

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -32,6 +32,17 @@ _build_single $board $shield $snippet $artifact cmake_args *west_args:
         mkdir -p "{{ out }}" && cp "$build_dir/zephyr/zmk.bin" "{{ out }}/$artifact.bin"
     fi
 
+# flash firmware for single board & shield combination
+# only needed for boards which do not support UF2
+_flash_single $board $shield $artifact:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    artifact="${artifact:-${shield:+${shield// /+}-}${board%%/*}}"
+    build_dir="{{ build / '$artifact' }}"
+
+    echo "Flashing firmware for $artifact..."
+    west flash -d "$build_dir"
+
 # build firmware for matching targets
 build expr *west_args:
     #!/usr/bin/env bash
@@ -87,6 +98,17 @@ draw: _check_yq_version
     yq -y "$jq_expr" "{{ draw }}/base.yaml" >"{{ draw }}/overview.yaml"
     keymap -c "{{ draw }}/config.yaml" draw "{{ draw }}/overview.yaml" -k "ferris/sweep" >"{{ draw }}/overview.svg"
     sed -i '/<text.*class="label"/d' "{{ draw }}/overview.svg"
+
+# flash firmware for matching targets
+flash expr:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    targets=$(just build_matrix={{build_matrix}} _parse_targets {{ expr }})
+
+    [[ -z $targets ]] && echo "No matching targets found. Aborting..." >&2 && exit 1
+    echo "$targets" | while IFS=, read -r board shield snippet artifact cmake_args; do
+        just _flash_single "$board" "$shield" "$artifact"
+    done
 
 # initialize west
 init:

--- a/Justfile
+++ b/Justfile
@@ -37,7 +37,7 @@ _build_single $board $shield $snippet $artifact cmake_args *west_args:
 _flash_single $board $shield $artifact:
     #!/usr/bin/env bash
     set -euo pipefail
-    artifact="${artifact:-${shield:+${shield// /+}-}${board%%/*}}"
+    artifact="${artifact:-${shield:+${shield// /+}-}${board//\//_}}"
     build_dir="{{ build / '$artifact' }}"
 
     echo "Flashing firmware for $artifact..."
@@ -100,7 +100,7 @@ draw: _check_yq_version
     sed -i '/<text.*class="label"/d' "{{ draw }}/overview.svg"
 
 # flash firmware for matching targets
-flash expr:
+flash expr: (build expr)
     #!/usr/bin/env bash
     set -euo pipefail
     targets=$(just build_matrix={{build_matrix}} _parse_targets {{ expr }})


### PR DESCRIPTION
This is useful for boards which do not use uf2 firmwares such as the Planck.

https://zmk.dev/docs/development/local-toolchain/build-flash#flashing