### PR TITLE
Bump west manifest pins

### DIFF
--- a/config/west.yml
+++ b/config/west.yml
@@ -31,7 +31,7 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: 6e2ef41e022d555b10f116e395832913f71717b3 # main (2026-08-18)
+      revision: 641514a97db345f499dd50b0360e594270f008fe # main (2026-08-31)
       import: app/west.yml
 
     # ZMK modules
@@ -43,16 +43,16 @@ manifest:
       revision: 62c201934711369d50a28df12e1d055d05cb6460 # main (2026-08-18)
     - name: zmk-helpers
       path: modules/zmk/helpers
-      revision: bc114546392b4615ac90a99140eaf21dde31209d # main (2026-08-18)
+      revision: 95edb8f15ef1d1bd8332810555f8cf5837fbdd27 # main (2026-08-31)
     - name: zmk-leader-key
       path: modules/zmk/leader-key
       revision: e894d9afa5164b7fff641db4194fc3d4d6e84bbb # main (2026-08-18)
     - name: zmk-tri-state
       path: modules/zmk/tri-state
-      revision: 269b13eb3f5491292b627ac3892589af32de3e17 # main (2026-08-18)
+      revision: 0c6eaf55d2da0d85b943e02d72831c2d8ea64501 # main (2026-08-31)
     - name: zmk-unicode
       path: modules/zmk/unicode
-      revision: a1e3d3eed54dea800b5342a251eb3b83eee3b5ec # main (2026-08-18)
+      revision: 5f458b6f1fd8ca83f4aba793c2a64916522507e9 # main (2026-08-31)
 
     # Avoid downloading GBs of unused Zephyr modules. Remove this section to
     # restore the default (needed for less common hardware).


### PR DESCRIPTION
Automated bump by [pin-west](https://github.com/urob/pin-west).

- **zmk**: `main (2026-08-18)` → `main (2026-08-31)` ([`6e2ef41...641514a`](https://github.com/zmkfirmware/zmk/compare/6e2ef41e022d555b10f116e395832913f71717b3...641514a97db345f499dd50b0360e594270f008fe))
- **zmk-helpers**: `main (2026-08-18)` → `main (2026-08-31)` ([`bc11454...95edb8f`](https://github.com/urob/zmk-helpers/compare/bc114546392b4615ac90a99140eaf21dde31209d...95edb8f15ef1d1bd8332810555f8cf5837fbdd27))
- **zmk-tri-state**: `main (2026-08-18)` → `main (2026-08-31)` ([`269b13e...0c6eaf5`](https://github.com/urob/zmk-tri-state/compare/269b13eb3f5491292b627ac3892589af32de3e17...0c6eaf55d2da0d85b943e02d72831c2d8ea64501))
- **zmk-unicode**: `main (2026-08-18)` → `main (2026-08-31)` ([`a1e3d3e...5f458b6`](https://github.com/urob/zmk-unicode/compare/a1e3d3eed54dea800b5342a251eb3b83eee3b5ec...5f458b6f1fd8ca83f4aba793c2a64916522507e9))

<details><summary>pin-west bump log</summary>

```
bump zmk: 6e2ef41e022d -> 641514a97db3 (branch main)
ok  zmk-adaptive-key: already at main (e5b335a7b107)
ok  zmk-auto-layer: already at main (62c201934711)
bump zmk-helpers: bc114546392b -> 95edb8f15ef1 (branch main)
ok  zmk-leader-key: already at main (e894d9afa516)
bump zmk-tri-state: 269b13eb3f54 -> 0c6eaf55d2da (branch main)
bump zmk-unicode: a1e3d3eed54d -> 5f458b6f1fd8 (branch main)
ok  zephyr: already at v4.1.0+zmk-fixes (10ba6d0cb38b)
imports: 8 project(s) pinned (0 added, 0 removed, 0 updated)
updated config/west.yml
```
</details>
